### PR TITLE
Refactor tag object to store integers, use unordered_map for re/ncoding

### DIFF
--- a/qa_handler.hpp
+++ b/qa_handler.hpp
@@ -2,13 +2,13 @@
 #define TAGINFO_VALIDATE_QA_HANDLER
 
 #include <algorithm>
+#include <iterator>
 #include <osmium/handler.hpp>
 #include <osmium/osm/types.hpp>
 #include <set>
 #include <tuple>
 #include <unordered_set>
 #include <vector>
-#include <iterator>
 
 #include "tag.hpp"
 #include "taginfo_parser.hpp"
@@ -18,7 +18,7 @@
 using namespace taginfo_validate;
 
 struct qa_handler : osmium::handler::Handler {
-  qa_handler(const taginfo_parser &taginfo, std::unordered_map<std::string, uint32_t>&string_catalogue)
+  qa_handler(const taginfo_parser &taginfo, std::unordered_map<std::string, uint32_t> &string_catalogue)
       : tags_on_areas(taginfo.tags_on_areas()), tags_on_nodes(taginfo.tags_on_nodes()),
         tags_on_ways(taginfo.tags_on_ways()), tags_on_relations(taginfo.tags_on_relations()),
         tags_on_any_object(taginfo.tags_on_any_object()), ST(string_catalogue){};
@@ -33,13 +33,14 @@ struct qa_handler : osmium::handler::Handler {
   void verifyAndStoreTags(const object::type &objectType, const tag_range &tagRange, const osmium::Tag &thePbfTag) {
     // first store in tag dictionary
     if (ST.find(thePbfTag.key()) == ST.end()) {
-        ST[thePbfTag.key()] = ST.size();
+      ST[thePbfTag.key()] = ST.size();
     }
     if (ST.find(thePbfTag.value()) == ST.end()) {
-        ST[thePbfTag.value()] = ST.size();
+      ST[thePbfTag.value()] = ST.size();
     }
     // Look for the given pbf tag's key in the range of acceptable keys
-    auto matching_key_tags = std::equal_range(tagRange.first, tagRange.second, tag{ST[thePbfTag.key()], {}, objectType}, keyCompare());
+    auto matching_key_tags =
+        std::equal_range(tagRange.first, tagRange.second, tag{ST[thePbfTag.key()], {}, objectType}, keyCompare());
     auto matching_key_tags_anyObject = std::equal_range(tags_on_any_object.first, tags_on_any_object.second,
                                                         tag{ST[thePbfTag.key()], {}, object::type::all}, keyCompare());
 
@@ -52,24 +53,24 @@ struct qa_handler : osmium::handler::Handler {
     // first check if given pbf tag matches an entry in the range of taginfo tags
     // with no object type specified because it's more likely to match first
     if (std::distance(matching_key_tags_anyObject.first, matching_key_tags_anyObject.second) != 0) {
-        for (auto tagIt = matching_key_tags_anyObject.first, end = matching_key_tags_anyObject.second; tagIt != end;
-             ++tagIt) {
-          if (!tagIt->value) {
-            // this is a tag in the taginfo file that only specifies a key
+      for (auto tagIt = matching_key_tags_anyObject.first, end = matching_key_tags_anyObject.second; tagIt != end;
+           ++tagIt) {
+        if (tagIt->value == 0) {
+          // this is a tag in the taginfo file that only specifies a key
+          hitlistAnyType.insert(tag{ST[thePbfTag.key()], ST[thePbfTag.value()], objectType});
+          return;
+        } else {
+          if (ST[thePbfTag.value()] == tagIt->value) {
             hitlistAnyType.insert(tag{ST[thePbfTag.key()], ST[thePbfTag.value()], objectType});
             return;
-          } else {
-            if (ST[thePbfTag.value()] == tagIt->value) {
-              hitlistAnyType.insert(tag{ST[thePbfTag.key()], ST[thePbfTag.value()], objectType});
-              return;
-            }
           }
         }
+      }
     }
 
     if (std::distance(matching_key_tags.first, matching_key_tags.second) != 0) {
       for (auto tagIt = matching_key_tags.first, end = matching_key_tags.second; tagIt != end; ++tagIt) {
-        if (!tagIt->value) {
+        if (tagIt->value == 0) {
           // this tag only specified an objectType and a key, it's a hit
           hitlistWithType.insert(tag{ST[thePbfTag.key()], ST[thePbfTag.value()], objectType});
           return;
@@ -116,44 +117,60 @@ struct qa_handler : osmium::handler::Handler {
     }
   }
 
+  void printTags(std::vector<tag> &tagVector) {
+    for (const auto &tag : tagVector) {
+      std::cout << tag.type << " " << reverse_ST[tag.key] << "=" << (tag.value == 0 ? "\"\"" : reverse_ST[tag.value]) << std::endl;
+    }
+  }
+
+  void reverseCatalogue(const std::unordered_map<std::string, uint32_t> &original) {
+    std::transform(begin(original), end(original), std::inserter(reverse_ST, std::end(reverse_ST)),
+                   [&](const std::pair<std::string, uint32_t> &entry) {
+                     return std::make_pair(entry.second, entry.first);
+                   });
+  }
+
   void printMissing() {
-    /*
+    reverseCatalogue(ST);
     std::cout << "# valid found tags, expected on any object type:" << std::endl;
     for (const auto &Hit : hitlistAnyType) {
-        std::cout << ST[Hit.key()] << "," << ST[Hit.value()] << "," ST[Hit.type] << std::endl;
+        std::cout << Hit.type << " " << reverse_ST[Hit.key] << "=" << reverse_ST[Hit.value] << std::endl;
     }
-    */
-
-    std::ostream_iterator<tag> out{std::cout, "\n"};
 
     std::vector<tag> missing_ways;
     std::cout << "# Way tags missing in provided pbf" << std::endl;
-    std::set_difference(tags_on_ways.first, tags_on_ways.second, hitlistWithType.begin(), hitlistWithType.end(), std::back_inserter(missing_ways), byUniqueHits{});
+    std::set_difference(tags_on_ways.first, tags_on_ways.second, hitlistWithType.begin(), hitlistWithType.end(),
+                        std::back_inserter(missing_ways), byUniqueHits{});
+    printTags(missing_ways);
 
     std::vector<tag> missing_nodes;
     std::cout << "# Node tags missing in provided pbf" << std::endl;
-    std::set_difference(tags_on_nodes.first, tags_on_nodes.second, hitlistWithType.begin(), hitlistWithType.end(), std::back_inserter(missing_nodes),
-                        byUniqueHits{});
+    std::set_difference(tags_on_nodes.first, tags_on_nodes.second, hitlistWithType.begin(), hitlistWithType.end(),
+                        std::back_inserter(missing_nodes), byUniqueHits{});
+    printTags(missing_nodes);
 
     std::vector<tag> missing_rels;
     std::cout << "# Relation tags missing in provided pbf" << std::endl;
-    std::set_difference(tags_on_relations.first, tags_on_relations.second, hitlistWithType.begin(), hitlistWithType.end(), std::back_inserter(missing_rels),
-                        byUniqueHits{});
+    std::set_difference(tags_on_relations.first, tags_on_relations.second, hitlistWithType.begin(),
+                        hitlistWithType.end(), std::back_inserter(missing_rels), byUniqueHits{});
+    printTags(missing_rels);
 
     std::vector<tag> missing_areas;
     std::cout << "# Area tags missing in provided pbf" << std::endl;
-    std::set_difference(tags_on_areas.first, tags_on_areas.second, hitlistWithType.begin(), hitlistWithType.end(), std::back_inserter(missing_areas),
-                        byUniqueHits{});
+    std::set_difference(tags_on_areas.first, tags_on_areas.second, hitlistWithType.begin(), hitlistWithType.end(),
+                        std::back_inserter(missing_areas), byUniqueHits{});
+    printTags(missing_areas);
 
     std::vector<tag> missing_any;
     std::cout << "# Tags with no object type specified missing in provided pbf" << std::endl;
-    std::set_difference(tags_on_any_object.first, tags_on_any_object.second, hitlistAnyType.begin(), hitlistAnyType.end(), std::back_inserter(missing_any),
-                        byUniqueHitsAnyType{});
+    std::set_difference(tags_on_any_object.first, tags_on_any_object.second, hitlistAnyType.begin(),
+                        hitlistAnyType.end(), std::back_inserter(missing_any), byUniqueHitsAnyType{});
+    printTags(missing_any);
   }
 
   struct byUniqueHitsAnyType {
     bool operator()(const tag &lhs, const tag &rhs) {
-      if (!lhs.value) {
+      if (lhs.value == 0) {
         return (std::tie(lhs.key) < std::tie(rhs.key));
       } else {
         return (std::tie(lhs.key, lhs.value) < std::tie(rhs.key, rhs.value));
@@ -163,7 +180,7 @@ struct qa_handler : osmium::handler::Handler {
 
   struct byUniqueHits {
     bool operator()(const tag &lhs, const tag &rhs) {
-      if (!lhs.value) {
+      if (lhs.value == 0) {
         return (std::tie(lhs.type, lhs.key) < std::tie(rhs.type, rhs.key));
       } else {
         return (std::tie(lhs.type, lhs.key, lhs.value) < std::tie(rhs.type, rhs.key, rhs.value));
@@ -177,7 +194,9 @@ struct qa_handler : osmium::handler::Handler {
   tag_range tags_on_ways;
   tag_range tags_on_relations;
   tag_range tags_on_any_object;
+  // catalogues mapping tag values to integers
   std::unordered_map<std::string, uint32_t> ST;
+  std::unordered_map<uint32_t, std::string> reverse_ST;
 
   std::unordered_set<tag, boost::hash<tag>> unknown_types;
   std::set<tag> hitlistWithType;

--- a/qa_handler.hpp
+++ b/qa_handler.hpp
@@ -40,9 +40,9 @@ struct qa_handler : osmium::handler::Handler {
     }
     // Look for the given pbf tag's key in the range of acceptable keys
     auto matching_key_tags =
-        std::equal_range(tagRange.first, tagRange.second, tag{ST[thePbfTag.key()], {}, objectType}, keyCompare());
+        std::equal_range(tagRange.first, tagRange.second, tag{ST[thePbfTag.key()], 0, objectType}, keyCompare());
     auto matching_key_tags_anyObject = std::equal_range(tags_on_any_object.first, tags_on_any_object.second,
-                                                        tag{ST[thePbfTag.key()], {}, object::type::all}, keyCompare());
+                                                        tag{ST[thePbfTag.key()], 0, object::type::all}, keyCompare());
 
     if (std::distance(matching_key_tags_anyObject.first, matching_key_tags_anyObject.second) == 0 &&
         std::distance(matching_key_tags.first, matching_key_tags.second) == 0) {

--- a/tag.hpp
+++ b/tag.hpp
@@ -47,10 +47,10 @@ std::ostream &operator<<(std::ostream &os, const type &rhs) {
 }
 
 struct tag {
-  std::string key;
-  std::string value;
+  uint32_t key;
+  uint32_t value;
   object::type type;
-  // make hashable, so tags can be stored in unordered_map
+  // make hashable, so tags can be stored in unordered_set
   friend std::size_t hash_value(tag const &t) {
     std::size_t seed = 0;
     boost::hash_combine(seed, t.key);
@@ -64,7 +64,6 @@ struct tag {
   };
   // overload less than to make sortable
   friend bool operator<(const tag &lhs, const tag &rhs) { return std::tie(lhs.type, lhs.key, lhs.value) < std::tie(rhs.type, rhs.key, rhs.value); };
-  friend std::ostream &operator<<(std::ostream &out, const tag &Tag) { return out << Tag.type << "\t" << Tag.key << "=" << (Tag.value.empty() ? "\"\"" : Tag.value); }
 };
 }
 

--- a/taginfo-validate.cc
+++ b/taginfo-validate.cc
@@ -3,6 +3,7 @@
 #include <stdexcept>
 #include <string>
 #include <unordered_set>
+#include <unordered_map>
 #include <vector>
 
 #include <osmium/io/any_input.hpp>
@@ -16,13 +17,15 @@
 using namespace taginfo_validate;
 
 int main(int argc, char **argv) try {
+  std::unordered_map<std::string, uint32_t> string_catalogue;
+
   const auto args = commandline::make_arguments(argc, argv);
-  const taginfo_parser taginfo{args.taginfo};
+  const taginfo_parser taginfo{args.taginfo, string_catalogue};
   const std::string osmFile = args.osm.string();
   bool unknowns = args.print_unknowns;
 
   osmium::io::Reader osmFileReader(osmFile);
-  qa_handler handler(taginfo);
+  qa_handler handler(taginfo, string_catalogue);
   osmium::apply(osmFileReader, handler);
   if (unknowns) {
     handler.printUnknowns();

--- a/taginfo-validate.cc
+++ b/taginfo-validate.cc
@@ -18,6 +18,7 @@ using namespace taginfo_validate;
 
 int main(int argc, char **argv) try {
   std::unordered_map<std::string, uint32_t> string_catalogue;
+  string_catalogue[""] = 0;
 
   const auto args = commandline::make_arguments(argc, argv);
   const taginfo_parser taginfo{args.taginfo, string_catalogue};

--- a/taginfo-validate.cc
+++ b/taginfo-validate.cc
@@ -18,15 +18,16 @@ using namespace taginfo_validate;
 
 int main(int argc, char **argv) try {
   std::unordered_map<std::string, uint32_t> string_catalogue;
+  std::unordered_map<uint32_t, std::string> reverse_string_catalogue;
   string_catalogue[""] = 0;
 
   const auto args = commandline::make_arguments(argc, argv);
-  const taginfo_parser taginfo{args.taginfo, string_catalogue};
+  const taginfo_parser taginfo{args.taginfo, string_catalogue, reverse_string_catalogue};
   const std::string osmFile = args.osm.string();
   bool unknowns = args.print_unknowns;
 
   osmium::io::Reader osmFileReader(osmFile);
-  qa_handler handler(taginfo, string_catalogue);
+  qa_handler handler(taginfo, string_catalogue, reverse_string_catalogue, unknowns);
   osmium::apply(osmFileReader, handler);
   if (unknowns) {
     handler.printUnknowns();

--- a/taginfo_parser.hpp
+++ b/taginfo_parser.hpp
@@ -128,23 +128,23 @@ struct taginfo_parser {
   };
 
   std::pair<tag_iter, tag_iter> tags_on_nodes() const {
-    return std::equal_range(begin(tags), end(tags), tag{{}, {}, object::type::node}, typeCompare());
+    return std::equal_range(begin(tags), end(tags), tag{0, 0, object::type::node}, typeCompare());
   };
 
   std::pair<tag_iter, tag_iter> tags_on_ways() const {
-    return std::equal_range(begin(tags), end(tags), tag{{}, {}, object::type::way}, typeCompare());
+    return std::equal_range(begin(tags), end(tags), tag{0, 0, object::type::way}, typeCompare());
   }
 
   std::pair<tag_iter, tag_iter> tags_on_relations() const {
-    return std::equal_range(begin(tags), end(tags), tag{{}, {}, object::type::relation}, typeCompare());
+    return std::equal_range(begin(tags), end(tags), tag{0, 0, object::type::relation}, typeCompare());
   }
 
   std::pair<tag_iter, tag_iter> tags_on_areas() const {
-    return std::equal_range(begin(tags), end(tags), tag{{}, {}, object::type::area}, typeCompare());
+    return std::equal_range(begin(tags), end(tags), tag{0, 0, object::type::area}, typeCompare());
   }
 
   std::pair<tag_iter, tag_iter> tags_on_any_object() const {
-    return std::equal_range(begin(tags), end(tags), tag{{}, {}, object::type::all}, typeCompare());
+    return std::equal_range(begin(tags), end(tags), tag{0, 0, object::type::all}, typeCompare());
   }
 };
 }

--- a/test/fixtures/nodes.expected.txt
+++ b/test/fixtures/nodes.expected.txt
@@ -1,9 +1,9 @@
 # valid found tags, expected on any object type:
-node	width=10
+node width=10
 # Way tags missing in provided pbf
 # Node tags missing in provided pbf
-node	highway=spacejam
-node	spacejam=""
+node highway=spacejam
+node spacejam=""
 # Relation tags missing in provided pbf
 # Area tags missing in provided pbf
 # Tags with no object type specified missing in provided pbf

--- a/test/fixtures/nodes.expected.txt
+++ b/test/fixtures/nodes.expected.txt
@@ -1,9 +1,26 @@
 # valid found tags, expected on any object type:
-node width=10
+node width=""
+
+
+# valid found tags, expected on any object type:
+node highway=traffic_signals
+node barrier=""
+
+
 # Way tags missing in provided pbf
+
+
 # Node tags missing in provided pbf
 node highway=spacejam
 node spacejam=""
+
+
 # Relation tags missing in provided pbf
+
+
 # Area tags missing in provided pbf
+
+
 # Tags with no object type specified missing in provided pbf
+
+


### PR DESCRIPTION
Unless this is run on a huge machine it eventually runs out of memory when parsing large input osm files. Storing parsed taginfo and input tags as an integer-based object rather than saves memory usage.

@daniel-j-h any specific code suggestions?
